### PR TITLE
Remove unused md5 include that otherwise prevents launching server

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,7 +2,6 @@ var express = require('express');
 var app = require('express')();
 var server = require('http').Server(app);
 var io = require('socket.io')(server);
-var md5 = require('MD5');
 
 app.use('/', express.static(__dirname + '/client'));
 app.get('/', function(req, res){


### PR DESCRIPTION
Removes the line that requires MD5 because it appears unused and having it included means that project won't run (error message says Cannot find module 'MD5').